### PR TITLE
add clock_nanosleep syscall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ tardis: tardis.c
 
 novdso.so: novdso.c
 	gcc -std=c99 -Wall -fPIC -shared -o novdso.so novdso.c
+
+clean:
+	rm -f tardis novdso.so

--- a/README.md
+++ b/README.md
@@ -36,13 +36,9 @@ relative for simplicity.
 Currently handled syscalls:
 
 - `nanosleep`
-
+- `clock_nanosleep`
 - `select`
-
 - `poll`
-
 - `gettimeofday`
-
 - `clock_gettime`
-
 - `time`

--- a/tardis.c
+++ b/tardis.c
@@ -98,6 +98,13 @@ void before_select(pid_t pid, struct user_regs_struct * uregs) {
 	}
 }
 
+void before_clock_nanosleep(pid_t pid, struct user_regs_struct * uregs) {
+	struct timespec rqtp;
+	read_block(pid, &rqtp, (void *)uregs->rdx, sizeof(struct timespec));
+	scale_timespec(&rqtp, 1.0/delayfactor, 0);
+	write_block(pid, &rqtp, (void *)uregs->rdx, sizeof(struct timespec));
+}
+
 /* post-syscall handlers */
 
 void after_gettimeofday(pid_t pid, struct user_regs_struct * uregs) {
@@ -119,6 +126,13 @@ void after_time(pid_t pid, struct user_regs_struct * uregs) {
 	ptrace(PTRACE_SETREGS, pid, 0, uregs);
 }
 
+void after_clock_nanosleep(pid_t pid, struct user_regs_struct * uregs) {
+	struct timespec rmtp;
+	read_block(pid, &rmtp, (void *)uregs->rcx, sizeof(struct timespec));
+	scale_timespec(&rmtp, 1.0/delayfactor, 0);
+	write_block(pid, &rmtp, (void *)uregs->rcx, sizeof(struct timespec));
+}
+
 int main(int argc, char *argv[], char *envp[]) {
 	
 	if (argc < 3) {
@@ -132,10 +146,12 @@ int main(int argc, char *argv[], char *envp[]) {
 	before_handlers[SYS_nanosleep] = before_nanosleep;
 	before_handlers[SYS_poll] = before_poll;
 	before_handlers[SYS_select] = before_select;
+	before_handlers[SYS_clock_nanosleep] = before_clock_nanosleep;
 	
 	after_handlers[SYS_gettimeofday] = after_gettimeofday;
 	after_handlers[SYS_clock_gettime] = after_clock_gettime;
 	after_handlers[SYS_time] = after_time;
+	after_handlers[SYS_clock_nanosleep] = after_clock_nanosleep;
 	
 	struct timespec sts;
 	for (clockid_t id = 0; id < NUM_CLKIDS; id++) {


### PR DESCRIPTION
I think this PR pretty much speaks for itself in terms of code.

I used TARDIS for a video game, and it didn't change the speed at first, so I used strace to find what syscall was missing. It was `clock_nanosleep`, which was being used exactly like `nanosleep` (i.e. `clock_nanosleep(CLOCK_REALTIME, 0, ...)`). With my modification, TARDIS works for that video game, although audio is totally broken, as is to be expected.