### PR TITLE
 ensure tardis exit code matches spawned program

### DIFF
--- a/tardis.c
+++ b/tardis.c
@@ -191,7 +191,7 @@ int main(int argc, char *argv[], char *envp[]) {
 		pid_t pid = waitpid(-1, &status, 0);
 		if (WIFEXITED(status)) {
 			if (pid == child) {
-				break;
+				exit(WEXITSTATUS(status));
 			} else {
 				continue;
 			}
@@ -227,6 +227,4 @@ int main(int argc, char *argv[], char *envp[]) {
 		leavesys[pid] ^= true;
 		ptrace(PTRACE_SYSCALL, pid, 0, 0);
 	}
-	
-	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
### Problem:
`tardis` ignores the exit code of the spawned program and returns 0.  
For example, `./tardis 1 1 /bin/bash -c "echo hello; exit 1"` will return 0.
Since we are looking to evaluate how `tardis` is affecting the spawned action, this will also include any changes to the action's return code.

### Solution:
We modify the exit of tardis to use `WEXITSTATUS(status)` instead of `exit(EXIT_SUCCESS)`

Below is an example of how the exit code for tardis will now be different: 
```
# before:
./tardis 1 1 /bin/bash -c "echo hello; exit 0" => 0
./tardis 1 1 /bin/bash -c "echo hello; exit 123" => 0

# after:
./tardis 1 1 /bin/bash -c "echo hello; exit 0" => 0
./tardis 1 1 /bin/bash -c "echo hello; exit 123" => 123
```