### PR TITLE
Revert original rqtp in after_clock_nanosleep insted of scaling rmtp

### DIFF
--- a/tardis.c
+++ b/tardis.c
@@ -126,11 +126,13 @@ void after_time(pid_t pid, struct user_regs_struct * uregs) {
 	ptrace(PTRACE_SETREGS, pid, 0, uregs);
 }
 
-void after_clock_nanosleep(pid_t pid, struct user_regs_struct * uregs) {
-	struct timespec rmtp;
-	read_block(pid, &rmtp, (void *)uregs->rcx, sizeof(struct timespec));
-	scale_timespec(&rmtp, 1.0/delayfactor, 0);
-	write_block(pid, &rmtp, (void *)uregs->rcx, sizeof(struct timespec));
+void after_clock_nanosleep(pid_t pid, struct user_regs_struct *uregs)
+{
+	// revert rqtp to the original value
+	struct timespec rqtp;
+	read_block(pid, &rqtp, (void *)uregs->rdx, sizeof(rqtp));
+	scale_timespec(&rqtp, delayfactor, 0);
+	write_block(pid, &rqtp, (void *)uregs->rdx, sizeof(rqtp));
 }
 
 int main(int argc, char *argv[], char *envp[]) {


### PR DESCRIPTION
In `after_clock_nanosleep` you try to downscale `rmtp` (the time remaining). This doesn't make sense to me since you modify the value the next `clock_nanosleep` call and downscale it by the same factor (again) if tracee retries sleeping after interrupt (ex: sleep command).

I believe the correct implementation would be to revert `rqtp` to original value before call and upscale `rmtp` so the `rmtp/rqtp` ratio remains relative to the time passed.

Sometimes &rmtp == &rqtp (the second portion of if). In this case we only need to upscale once.

Also you messed up user-mode and kernel-mode ABIs. The kernel one has 4th param in `r10` instead of `rcx`.