### PR TITLE
Add simple testing framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 all: tardis novdso.so
 
+tests: tests/*
+	(cd tests; find . -name '*.c' | xargs -I@ echo @ | rev | cut -d '.' -f 2- | rev | xargs -I@ gcc -std=c99 -Wall -o ./bin/@ @.c)
+
+.PHONY: test
+test: tests tardis
+	python3 tests/run_tests.py
+
 tardis: tardis.c
 	gcc tardis.c -o tardis -lm -Wall -Ofast -std=c99 -DPID_MAX=$(shell cat /proc/sys/kernel/pid_max)
 
@@ -7,4 +14,5 @@ novdso.so: novdso.c
 	gcc -std=c99 -Wall -fPIC -shared -o novdso.so novdso.c
 
 clean:
+	rm -f tests/bin/*
 	rm -f tardis novdso.so

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,24 @@
+import os
+
+def main():
+    bin_folder = "./tests/bin/"
+
+    # Iterate over all the files in the bin folder
+    for file in os.listdir(bin_folder):
+        #  Check if the file is a regular file
+        if os.path.isfile(os.path.join(bin_folder, file)) and not file.startswith("."):
+            print(f"Testing [{file}]: ", end="")
+            try:
+                # Test no tardis timeout
+                code = os.system(f"timeout 2 {bin_folder}{file}")
+                assert os.WEXITSTATUS(code) == 124, f"original did not time out"
+
+                # Test with tardis no timeout
+                code = os.system(f"timeout 2 ./tardis 10 10 {bin_folder}{file}")
+                assert os.WEXITSTATUS(code) != 124, f"timed out with TARDIS"
+                print("\033[92mOK\033[0m")
+            except AssertionError as e:
+                    print(f"\033[91mFAILED\033[0m ({e})")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_clock_nanosleep_in_fork.c
+++ b/tests/test_clock_nanosleep_in_fork.c
@@ -1,0 +1,24 @@
+#define _DEFAULT_SOURCE
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/auxv.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[], char *envp[]) {
+    pid_t child = fork();
+    if (child == 0) {
+        struct timespec time = {.tv_sec = 10, .tv_nsec = 0};
+        clock_nanosleep(0, 0, &time, &time);
+        exit(EXIT_SUCCESS);
+    }
+
+    wait(NULL);
+
+    return 0;
+}

--- a/tests/test_clock_nanosleep_with_execve.c
+++ b/tests/test_clock_nanosleep_with_execve.c
@@ -1,0 +1,23 @@
+#define _DEFAULT_SOURCE
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/auxv.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[], char *envp[]) {
+    pid_t child = fork();
+    if (child == 0) {
+        char *args[] = {"/bin/sleep", "10", NULL};
+        execve(args[0], &args, NULL);
+        exit(EXIT_SUCCESS);
+    }
+
+    wait(NULL);
+    exit(EXIT_SUCCESS);
+}

--- a/tests/test_clock_nanosleep_with_rmtp_eq_rqtp.c
+++ b/tests/test_clock_nanosleep_with_rmtp_eq_rqtp.c
@@ -1,0 +1,18 @@
+#define _DEFAULT_SOURCE
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/auxv.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[], char *envp[]) {
+    struct timespec time = {.tv_sec = 10, .tv_nsec = 0};
+    clock_nanosleep(0, 0, &time, &time);
+
+    return 0;
+}

--- a/tests/test_clock_nanosleep_with_rmtp_null.c
+++ b/tests/test_clock_nanosleep_with_rmtp_null.c
@@ -1,0 +1,18 @@
+#define _DEFAULT_SOURCE
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/auxv.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[], char *envp[]) {
+    struct timespec time = {.tv_sec = 10, .tv_nsec = 0};
+    clock_nanosleep(0, 0, &time, NULL);
+
+    return 0;
+}


### PR DESCRIPTION
Wrote some tests to use for my vDSO fix. Simple python wrapper that checks if a program will timeout without tardis and won't with.

Some tests will fail (as they should) until #12 is merged. Probably also needs #13 on some systems to work correctly 🤔.

Addresses #4.